### PR TITLE
Remove extra comma from netkan

### DIFF
--- a/KRnD.netkan
+++ b/KRnD.netkan
@@ -32,5 +32,5 @@
         { "name" : "ProceduralParts-Extended" },
         { "name" : "ProceduralProbes" },
         { "name" : "TweakScale" }
-    ],
+    ]
 }


### PR DESCRIPTION
I was prototyping a stats gathering script (details unimportant here), and I got an error message pointing out a syntax error in this file. Currently the CKAN bot itself is not complaining about this, but I don't know whether that's because it's working around the problem or failing so completely that no error message is preserved. Either way, might as well fix it.